### PR TITLE
Initialize parameters plot through pandas DataFrame

### DIFF
--- a/ertviz/controllers/parameter_controller.py
+++ b/ertviz/controllers/parameter_controller.py
@@ -1,7 +1,4 @@
-import re
-from tests import data
 import dash
-import json
 from dash.exceptions import PreventUpdate
 from dash.dependencies import Input, Output, State
 

--- a/ertviz/controllers/parameter_controller.py
+++ b/ertviz/controllers/parameter_controller.py
@@ -1,11 +1,12 @@
 import re
+from tests import data
 import dash
 import json
 from dash.exceptions import PreventUpdate
 from dash.dependencies import Input, Output, State
 
 from ertviz.controllers import parse_url_query
-from ertviz.models import EnsembleModel
+from ertviz.models import EnsembleModel, HistogramPlotModel
 from ertviz.data_loader import get_ensemble_url
 
 
@@ -69,13 +70,13 @@ def parameter_controller(parent, app):
             raise PreventUpdate
 
         param = parent.parameter_models[parameter]
-        param.update_realizations()
-        param.update_selection(selection)
-        param.set_plot_param(
-            hist="hist" in hist_check_values, kde="kde" in hist_check_values
+        parent.parameter_plot = HistogramPlotModel(
+            param.data_df(),
+            hist="hist" in hist_check_values,
+            kde="kde" in hist_check_values,
         )
-        parent.parameter_plot = param
-        return param.repr
+        parent.parameter_plot.selection = selection
+        return parent.parameter_plot.repr
 
     @app.callback(
         Output(parent.uuid("parameter-selector"), "value"),

--- a/ertviz/models/__init__.py
+++ b/ertviz/models/__init__.py
@@ -14,6 +14,6 @@ def indexes_to_axis(indexes):
 from .observation import Observation
 from .realization import Realization
 from .response import Response
-from .plot_model import PlotModel, ResponsePlotModel
-from .parameter_model import ParameterRealizationModel, PriorModel, ParametersModel
+from .plot_model import PlotModel, ResponsePlotModel, HistogramPlotModel
+from .parameter_model import PriorModel, ParametersModel
 from .ensemble_model import EnsembleModel

--- a/ertviz/models/ensemble_model.py
+++ b/ertviz/models/ensemble_model.py
@@ -3,7 +3,6 @@ from ertviz.models import Response
 
 from ertviz.models.parameter_model import (
     PriorModel,
-    ParameterRealizationModel,
     ParametersModel,
 )
 

--- a/ertviz/models/parameter_model.py
+++ b/ertviz/models/parameter_model.py
@@ -12,13 +12,6 @@ class PriorModel:
         self.function_parameter_values = function_parameter_values
 
 
-class ParameterRealizationModel:
-    def __init__(self, name, value):
-        self.name = name
-        self.value = value
-        self.selected = True
-
-
 class ParametersModel:
     def __init__(self, **kwargs):
         self.group = kwargs["group"]
@@ -26,12 +19,7 @@ class ParametersModel:
         self.priors = kwargs["prior"]
         self._schema_url = kwargs["schema_url"]
         self._realizations = kwargs.get("realizations")
-        self.set_plot_param(hist=kwargs.get("hist", True), kde=kwargs.get("kde", True))
         self._data_df = None
-
-    def set_plot_param(self, hist=True, kde=True):
-        self._hist_enabled = hist
-        self._kde_enabled = kde
 
     def data_df(self):
         if self._data_df is None:
@@ -41,63 +29,5 @@ class ParametersModel:
                 schema["name"]
                 for schema in realizations_schema["parameter_realizations"]
             ]
+            self._data_df.index.name = self.key
         return self._data_df
-
-    def update_realizations(self, data_df=None):
-        if data_df is None:
-            data_df = self.data_df()
-        if self._realizations is None:
-            self._realizations = [
-                ParameterRealizationModel(col, data_df[col].values[0])
-                for col in data_df
-            ]
-
-    def update_selection(self, selection):
-        if selection:
-            for real in self._realizations:
-                real.selected = real.name in selection
-        else:
-            for real in self._realizations:
-                real.selected = True
-
-    @property
-    def realizations(self):
-        return [real for real in self._realizations if real.selected]
-
-    @property
-    def realization_values(self):
-        return [real.value for real in self.realizations]
-
-    @property
-    def realization_names(self):
-        return [real.name for real in self.realizations]
-
-    @property
-    def data_frame(self):
-        return pandas.DataFrame(
-            {
-                self.key: [real.value for real in self.realizations],
-            }
-        )
-
-    @property
-    def plot_ids(self):
-        return {plot_idx: real.name for plot_idx, real in enumerate(self.realizations)}
-
-    @property
-    def repr(self):
-        bin_count = int(math.ceil(math.sqrt(len(self.data_frame.index))))
-        bin_size = float(
-            (self.data_frame.max().values - self.data_frame.min().values) / bin_count
-        )
-        fig = ff.create_distplot(
-            [self.realization_values],
-            [self.key],
-            show_hist=self._hist_enabled,
-            show_curve=self._kde_enabled,
-            bin_size=bin_size,
-        )
-        fig.update_layout(clickmode="event+select")
-
-        fig.update_layout(uirevision=True)
-        return fig

--- a/ertviz/models/plot_model.py
+++ b/ertviz/models/plot_model.py
@@ -1,4 +1,6 @@
 import plotly.graph_objects as go
+import plotly.figure_factory as ff
+import math
 
 
 class PlotModel:
@@ -71,3 +73,40 @@ class ResponsePlotModel:
     @property
     def plot_ids(self):
         return {idx: rel.name for idx, rel in enumerate(self._realization_plots)}
+
+
+class HistogramPlotModel:
+    def __init__(self, data_df, hist=True, kde=True):
+        self._hist_enabled = hist
+        self._kde_enabled = kde
+        self._data_df = data_df
+        self.selection = []
+
+    @property
+    def data_df(self):
+        if self.selection:
+            return self._data_df[self.selection]
+        return self._data_df
+
+    @property
+    def plot_ids(self):
+        return {plot_idx: real.name for plot_idx, real in enumerate(self._data_df)}
+
+    @property
+    def repr(self):
+        bin_count = int(math.ceil(math.sqrt(len(self.data_df.values.flatten()))))
+        bin_size = float(
+            (self.data_df.max(axis=1).values - self.data_df.min(axis=1).values)
+            / bin_count
+        )
+        fig = ff.create_distplot(
+            [list(self.data_df.values.flatten())],
+            [self.data_df.index.name],
+            show_hist=self._hist_enabled,
+            show_curve=self._kde_enabled,
+            bin_size=bin_size,
+        )
+        fig.update_layout(clickmode="event+select")
+
+        fig.update_layout(uirevision=True)
+        return fig

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,3 +2,4 @@ pytest
 pytest-mock
 pylint
 black
+scipy

--- a/tests/plots/test_controller.py
+++ b/tests/plots/test_controller.py
@@ -88,7 +88,7 @@ def test_histogram_plot_representation():
     data_df.index.name = "key_name"
 
     plot = HistogramPlotModel(data_df, hist=True, kde=False)
-    plot.selection = [range(5)]
+    plot.selection = range(5)
     plot = plot.repr
     np.testing.assert_equal(plot.data[0].x, data.flatten()[:5])
     assert plot.data[0].histnorm == "probability density"

--- a/tests/plots/test_controller.py
+++ b/tests/plots/test_controller.py
@@ -10,7 +10,7 @@ from ertviz.controllers.response_controller import (
 from ertviz.controllers.ensemble_selector_controller import _construct_graph
 from ertviz.data_loader import get_ensembles
 from ertviz.models import EnsembleModel
-from ertviz.models import ParametersModel
+from ertviz.models import HistogramPlotModel
 
 
 def test_observation_plot_representation():
@@ -82,15 +82,14 @@ def test_ensemble_selector_graph_constructor(mock_request, mock_get_info):
     assert parent_child_edge in graph_data
 
 
-def test_parameter_realizations_plot_representation():
+def test_histogram_plot_representation():
     data = np.random.rand(20).reshape(-1, 20)
     data_df = pd.DataFrame(data=data, index=range(1), columns=range(20))
+    data_df.index.name = "key_name"
 
-    param = ParametersModel(group="group", key="key", prior=None, schema_url=None)
-    param.update_realizations(data_df)
-    param.set_plot_param(hist=True, kde=False)
-
-    plot = param.repr
-    np.testing.assert_equal(plot.data[0].x, data.flatten())
+    plot = HistogramPlotModel(data_df, hist=True, kde=False)
+    plot.selection = [range(5)]
+    plot = plot.repr
+    np.testing.assert_equal(plot.data[0].x, data.flatten()[:5])
     assert plot.data[0].histnorm == "probability density"
     assert plot.data[0].autobinx == False

--- a/tests/plots/test_controller.py
+++ b/tests/plots/test_controller.py
@@ -10,6 +10,7 @@ from ertviz.controllers.response_controller import (
 from ertviz.controllers.ensemble_selector_controller import _construct_graph
 from ertviz.data_loader import get_ensembles
 from ertviz.models import EnsembleModel
+from ertviz.models import ParametersModel
 
 
 def test_observation_plot_representation():
@@ -79,3 +80,17 @@ def test_ensemble_selector_graph_constructor(mock_request, mock_get_info):
     }
     assert parent_ensemble_node in graph_data
     assert parent_child_edge in graph_data
+
+
+def test_parameter_realizations_plot_representation():
+    data = np.random.rand(20).reshape(-1, 20)
+    data_df = pd.DataFrame(data=data, index=range(1), columns=range(20))
+
+    param = ParametersModel(group="group", key="key", prior=None, schema_url=None)
+    param.update_realizations(data_df)
+    param.set_plot_param(hist=True, kde=False)
+
+    plot = param.repr
+    np.testing.assert_equal(plot.data[0].x, data.flatten())
+    assert plot.data[0].histnorm == "probability density"
+    assert plot.data[0].autobinx == False


### PR DESCRIPTION
To separate schema / rest api from plots, also parameters plot need to be initiated from DataFrame. This also simplifies test implementation for plots.
Resoloves #39 